### PR TITLE
Make output specifictions for msout empty

### DIFF
--- a/rapthor/pipeline/steps/ddecal_solve_complexgain.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_complexgain.cwl
@@ -14,7 +14,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=complexgain

--- a/rapthor/pipeline/steps/ddecal_solve_complexgain1.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_complexgain1.cwl
@@ -14,7 +14,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=complexgain

--- a/rapthor/pipeline/steps/ddecal_solve_complexgain2.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_complexgain2.cwl
@@ -14,7 +14,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=complexgain

--- a/rapthor/pipeline/steps/ddecal_solve_complexgain_debug.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_complexgain_debug.cwl
@@ -14,7 +14,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=complexgain

--- a/rapthor/pipeline/steps/ddecal_solve_scalarcomplexgain.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_scalarcomplexgain.cwl
@@ -13,7 +13,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=scalarcomplexgain

--- a/rapthor/pipeline/steps/ddecal_solve_scalarphase.cwl
+++ b/rapthor/pipeline/steps/ddecal_solve_scalarphase.cwl
@@ -12,7 +12,7 @@ requirements:
 
 arguments:
   - msin.datacolumn=DATA
-  - msout=.
+  - msout=
   - steps=[solve]
   - solve.type=ddecal
   - solve.mode=scalarphase


### PR DESCRIPTION
In order to allow read-only access, the msout specification must be empty, not "."
This has been fixed in the affected CWL-files